### PR TITLE
feat: use `Union` instead of `|` for older Python versions

### DIFF
--- a/src/nopecha/api/_base.py
+++ b/src/nopecha/api/_base.py
@@ -2,6 +2,7 @@ import typing
 from abc import ABC, abstractmethod
 from logging import getLogger
 from urllib.parse import urlencode
+from typing import Union
 
 from .types import (
     AudioRecognitionRequest,
@@ -37,14 +38,14 @@ class UniformResponse(typing.NamedTuple):
 
 
 class APIClientMixin:
-    key: str | None = None
+    key: Union[str, None] = None
     post_max_attempts: int = 10
     get_max_attempts: int = 120
     host = "https://api.nopecha.com"
 
     def __init__(
         self,
-        key: str | None = None,
+        key: Union[str, None] = None,
         *,
         post_max_attempts: int = 10,
         get_max_attempts: int = 120,


### PR DESCRIPTION
Today I had a long incident with paddleocr because recent versions no longer support cpu that are not compatible with avx instructions so I had to use Python 3.8.10 to solve that since for that version there are wheels that support noavx, the project needed the nopecha package but I saw that internally it used `|` instead of `Union` for typing so I said to myself "wow just because of this a lot of people can't use nopecha with cp38", typing using `|` was introduced for Python versions 3.10 and higher as seen here in [PEP 604](https://peps.python.org/pep-0604/)